### PR TITLE
Fix issue #8.

### DIFF
--- a/lib/rchardet/jpcntx.rb
+++ b/lib/rchardet/jpcntx.rb
@@ -14,12 +14,12 @@
 # modify it under the terms of the GNU Lesser General Public
 # License as published by the Free Software Foundation; either
 # version 2.1 of the License, or (at your option) any later version.
-# 
+#
 # This library is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
 # Lesser General Public License for more details.
-# 
+#
 # You should have received a copy of the GNU Lesser General Public
 # License along with this library; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
@@ -137,9 +137,9 @@ module CharDet
       return if @done
 
       # The buffer we got is byte oriented, and a character may span in more than one
-      # buffers. In case the last one or two byte in last buffer is not complete, we 
+      # buffers. In case the last one or two byte in last buffer is not complete, we
       # record how many byte needed to complete that character and skip these bytes here.
-      # We can choose to record those bytes as well and analyse the character once it 
+      # We can choose to record those bytes as well and analyse the character once it
       # is complete, but since a character will not make much difference, by simply skipping
       # this character will simply our logic and improve performance.
       i = @needToSkipCharNum
@@ -195,10 +195,10 @@ module CharDet
       if aStr.length > 1
         second = aStr[1, 1]
         if (first == "\202") and (second >= "\x9F") and (second <= "\xF1")
-          return aStr[1] - 0x9F, charLen
+          return aStr[1].ord - 0x9F, charLen
         end
       end
-      
+
       return -1, charLen
     end
   end
@@ -220,7 +220,7 @@ module CharDet
       if aStr.length > 1
         second = aStr[1, 1]
         if (first == "\xA4") and (second >= "\xA1") and (second <= "\xF3")
-          return aStr[1] - 0xA1, charLen
+          return aStr[1].ord - 0xA1, charLen
         end
       end
 


### PR DESCRIPTION
In the Python version of this code, there's a wrap_ord function that converts
characters into numbers. In lib/rchardet/jpcntx.rb there's no mention of this
function and we're trying to simply take numbers away from chars, which does
not work. Fixed this so that we're subtracting from the character's ordinal
number.
