### PR TITLE
Fix encoding

### DIFF
--- a/lib/rchardet/universaldetector.rb
+++ b/lib/rchardet/universaldetector.rb
@@ -1,3 +1,4 @@
+# encoding: US-ASCII
 ######################## BEGIN LICENSE BLOCK ########################
 # The Original Code is Mozilla Universal charset detector code.
 #


### PR DESCRIPTION
While using with rails 3:

```
SyntaxError: .../vendor/bundle/gems/rchardet-1.3.1/lib/rchardet/universaldetector.rb:39: invalid multibyte escape: /[\x80-\xFF]/
from .../vendor/bundle/gems/activesupport-3.2.17/lib/active_support/dependencies.rb:251:in `require'
```
