### PR TITLE
Add LICENSE file to gem files

### DIFF
--- a/rchardet.gemspec
+++ b/rchardet.gemspec
@@ -5,7 +5,7 @@ Gem::Specification.new "rchardet", CharDet::VERSION do |s|
   s.email      = ["michael@grosser.it", "jeff@somethingsimilar.com"]
   s.homepage   = "https://github.com/jmhodges/rchardet"
   s.summary    = "Character encoding auto-detection in Ruby. As smart as your browser. Open source."
-  s.files      = Dir["lib/**/*"]
+  s.files      = Dir["lib/**/*", "LGPL-LICENSE.txt"]
   s.license    = "LGPL"
   s.required_ruby_version = ">= 2.6.0"
 end


### PR DESCRIPTION
Adding a `LICENSE` file to the bundled gem package is common practice. This way, automated OSS license compliance tools will be able to collect the full text of the license.