### PR TITLE
Fix warnings about mutating string literals

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,9 @@ jobs:
       fail-fast: false
       matrix:
         ruby:
+          - '3.4'
+          - '3.3'
+          - '3.2'
           - '3.1'
           - '3.0'
           - '2.7'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,13 +2,14 @@ GEM
   remote: https://rubygems.org/
   specs:
     bump (0.10.0)
-    maxitest (4.1.0)
-      minitest (>= 5.0.0, < 5.15.0)
-    minitest (5.14.4)
+    maxitest (5.8.0)
+      minitest (>= 5.14.0, < 5.26.0)
+    minitest (5.25.4)
     rake (13.0.6)
 
 PLATFORMS
   arm64-darwin-21
+  arm64-darwin-24
   x86_64-linux
 
 DEPENDENCIES

--- a/lib/rchardet/mbcharsetprober.rb
+++ b/lib/rchardet/mbcharsetprober.rb
@@ -34,7 +34,7 @@ module CharDet
       super
       @distributionAnalyzer = nil
       @codingSM = nil
-      @lastChar = "\x00\x00"
+      @lastChar = +"\x00\x00"
     end
 
     def reset
@@ -45,7 +45,7 @@ module CharDet
       if @distributionAnalyzer
         @distributionAnalyzer.reset()
       end
-      @lastChar = "\x00\x00"
+      @lastChar = +"\x00\x00"
     end
 
     def get_charset_name


### PR DESCRIPTION
In the next version, Ruby will freeze string literals by default. 3.4 issues a warning when you modify such a string. This PR is a workaround for these warnings.